### PR TITLE
create .babelrc in example folder

### DIFF
--- a/examples/.babelrc
+++ b/examples/.babelrc
@@ -1,0 +1,3 @@
+{
+  "babelrc": false
+}


### PR DESCRIPTION
to disable nextjs using .babelrc in root folder even run [yarn run dev] in examples' folder.